### PR TITLE
Handle missing FSFW submodule during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,20 @@ project(fsfw-from-zero VERSION 0.1.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Add the framework dependency
+# Add the framework dependency. If the FSFW submodule is not present we still
+# want to be able to compile the basic workshop executables. In that case we
+# provide a dummy interface target so the rest of the CMake configuration keeps
+# working without requiring the actual framework checkout.
 set(FSFW_OSAL host CACHE STRING "FSFW OSAL")
 set(FSFW_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR})
-add_subdirectory(fsfw)
+
+set(FSFW_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/fsfw)
+if(EXISTS ${FSFW_SOURCE_DIR}/CMakeLists.txt)
+    add_subdirectory(${FSFW_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/fsfw)
+else()
+    message(WARNING "FSFW submodule not found. Building with stub library.")
+    add_library(fsfw INTERFACE)
+endif()
 
 # Add our executable and its only source file
 add_executable(fsfw-from-zero main.cpp)


### PR DESCRIPTION
## Summary
- allow building the project even when the FSFW submodule is not present by creating an interface stub
- emit a warning so users know that the real framework was not configured

## Testing
- cmake ..
- cmake --build . -j
- ./fsfw-from-zero


------
https://chatgpt.com/codex/tasks/task_e_68dc295bac2c8327bff74757c90b7791